### PR TITLE
Fix link to MDI website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/material_design_icons.svg)](https://badge.fury.io/rb/material_design_icons)
 
-'material_design_icons' enables you to generate both HTML tags and inline SVG of [Material Design Icons](http://www.materialdesignicons.com/) for your Ruby on Rails projects.
+'material_design_icons' enables you to generate both HTML tags and inline SVG of [Material Design Icons](http://materialdesignicons.com/) for your Ruby on Rails projects.
 
 ## Installation
 


### PR DESCRIPTION
The link to Material design icons website doesn't work - it shows a holder page about a hosting provider.
 
Dropping the `www` fixes it.