### PR TITLE
Remove svg webfont

### DIFF
--- a/assets/stylesheets/materialdesignicons.css.erb
+++ b/assets/stylesheets/materialdesignicons.css.erb
@@ -4,12 +4,11 @@
 //= depend_on_asset "materialdesignicons-webfont.woff2"
 //= depend_on_asset "materialdesignicons-webfont.woff"
 //= depend_on_asset "materialdesignicons-webfont.ttf"
-//= depend_on_asset "materialdesignicons-webfont.svg"
 
 @font-face {
   font-family: "Material Design Icons";
   src: url("<%= font_path('materialdesignicons-webfont.eot') %>");
-  src: url("<%= font_path('materialdesignicons-webfont.eot?#iefix') %>") format("embedded-opentype"), url("<%= font_path('materialdesignicons-webfont.woff2') %>") format("woff2"), url("<%= font_path('materialdesignicons-webfont.woff') %>") format("woff"), url("<%= font_path('materialdesignicons-webfont.ttf') %>") format("truetype"), url("<%= font_path('materialdesignicons-webfont.svg') %>#materialdesigniconsregular") format("svg");
+  src: url("<%= font_path('materialdesignicons-webfont.eot?#iefix') %>") format("embedded-opentype"), url("<%= font_path('materialdesignicons-webfont.woff2') %>") format("woff2"), url("<%= font_path('materialdesignicons-webfont.woff') %>") format("woff"), url("<%= font_path('materialdesignicons-webfont.ttf') %>") format("truetype");
   font-weight: normal;
   font-style: normal;
 }

--- a/lib/material_design_icons/rails/engine.rb
+++ b/lib/material_design_icons/rails/engine.rb
@@ -6,7 +6,7 @@ module MaterialDesignIcons
           app.config.assets.paths << root.join('assets', sub).to_s
         end
 
-        %w(eot svg ttf woff woff2).each do |ext|
+        %w(eot ttf woff woff2).each do |ext|
           app.config.assets.precompile << "materialdesignicons-webfont.#{ext}"
         end
       end


### PR DESCRIPTION
The svg webfont was deleted with the last update. 
this change removes it completely.